### PR TITLE
added --fix option to eslint rule to enable windows eslint usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "generate-bridge-json": "node tools/csv2json.js",
     "build": "parcel build src/index.html",
-    "eslint": "eslint tools src test",
+    "eslint": "eslint --fix tools src test",
     "prettier": "prettier --single-quote --write \"{tools,src,test}/**/*.{js,css}\"",
     "check-prettier": "prettier --single-quote --list-different \"{tools,src,test}/**/*.{js,css}\"",
     "lint": "npm run eslint && npm run check-prettier",


### PR DESCRIPTION
Added --fix option when running eslint rule from package.json.
This will enable users to run `npm run eslint` on windows machine without triggering linebreak errors.
This was the recommended fix from [eslint.org](https://eslint.org/docs/rules/linebreak-style).