### PR TITLE
Fix #8, #9 - Do a better job with ordering in geo startup, error messages

### DIFF
--- a/src/fake-geolocation.js
+++ b/src/fake-geolocation.js
@@ -3,6 +3,12 @@
 const log = require('./log');
 const map = require('./map');
 
+// For debugging, use Seneca@York
+const senecaAtYork = {
+  lat: 43.7713,
+  lng: -79.4989
+};
+
 log.info(
   'Override Geolocation. Use `window.fakeGeo` in console or double-click map to move'
 );
@@ -13,6 +19,13 @@ const callbacks = [];
 navigator.geolocation.watchPosition = (success, error) => {
   let watchId = callbacks.length;
   callbacks.push({ success, error });
+
+  if (callbacks.length === 1) {
+    // Trigger an initial position update
+    log.info('Using Seneca@York as initial geographic position in debug mode');
+    window.fakeGeo.moveTo(senecaAtYork.lat, senecaAtYork.lng);
+  }
+
   return watchId;
 };
 

--- a/src/fake-geolocation.js
+++ b/src/fake-geolocation.js
@@ -36,11 +36,6 @@ window.fakeGeo = {
   simulateError: err => updateCallers('error', err)
 };
 
-// Get the current position so we can report it on startup
-navigator.geolocation.getCurrentPosition(pos => {
-  updateCallers('success', pos);
-});
-
 // If the user double-clicks on the map, jump to that position
 map.on('dblclick', e => {
   let lat = e.latlng.lat;

--- a/src/geo.js
+++ b/src/geo.js
@@ -56,25 +56,11 @@ const geoErrorHandler = err => {
   module.exports.emit('error', err);
 };
 
-/**
- * Browser Geolocation API - watch for live updates to position.
- * https://developer.mozilla.org/en-US/docs/Web/API/Geolocation/Using_geolocation
- */
-module.exports.watchPosition = () => {
-  if (!('geolocation' in navigator)) {
-    geoErrorHandler(new Error('Unable to access geolocation information'));
-    return;
-  }
-
-  let success = position => {
-    let lat = position.coords.latitude;
-    let lng = position.coords.longitude;
-    log.info(`Geolocation position update: lat=${lat}, lng=${lng}`);
-    module.exports.emit('update', lat, lng);
-  };
-
-  navigator.geolocation.watchPosition(success, geoErrorHandler);
-  log.info('Starting to watch for geolocation position updates');
+const geoSuccessHandler = position => {
+  let lat = position.coords.latitude;
+  let lng = position.coords.longitude;
+  log.debug(`Geolocation position update: lat=${lat}, lng=${lng}`);
+  module.exports.emit('update', lat, lng);
 };
 
 /**
@@ -87,25 +73,6 @@ module.exports.init = () => {
     return;
   }
 
-  let success = position => {
-    let lat = position.coords.latitude;
-    let lng = position.coords.longitude;
-    let duration = Date.now() - start;
-    log.info(
-      `Initial Geolocation position acquired: lat=${lat}, lng=${lng} took ${duration}ms`
-    );
-    module.exports.emit('ready', lat, lng);
-  };
-
-  let start = Date.now();
-  let geoOptions = {
-    timeout: 15 * 1000, // timeout after 15s of waiting
-    maximumAge: 60 * 1000 // use any cached value from the past hour
-  };
-  navigator.geolocation.getCurrentPosition(
-    success,
-    geoErrorHandler,
-    geoOptions
-  );
-  log.info('Requesting initial position from browser...');
+  navigator.geolocation.watchPosition(geoSuccessHandler, geoErrorHandler);
+  log.info('Starting to watch for geolocation position updates');
 };

--- a/src/index.html
+++ b/src/index.html
@@ -14,6 +14,7 @@
         <div class="sk-cube4 sk-cube"></div>
         <div class="sk-cube3 sk-cube"></div>
       </div>
+      <p class="loading-info">Finding your current location...</p>
     </div>
 
     <!-- Map div for Leaflet -->

--- a/src/index.js
+++ b/src/index.js
@@ -45,7 +45,9 @@ map.on('update', bounds => {
 });
 
 // Wait until we know where we are, then show the map centred on that point
-geo.once('ready', (lat, lng) => {
+geo.once('update', (lat, lng) => {
+  log.info('Got initial geolocation info, starting map UI');
+
   // Load a map, centered on our current position
   map.init(lat, lng);
 
@@ -73,19 +75,22 @@ geo.once('ready', (lat, lng) => {
   });
 });
 
+// Deal with any errors that might happen from geolocation update requests
 geo.once('error', err => {
   let msg;
-  if (err.code === 1 /* permission denied */) {
+
+  /* permission denied */
+  if (err.code === 1) {
     msg = 'Permission denied getting your location.';
-  } else if (
-    err.code ===
-    2 /* position unavailable (error response from location provider) */
-  ) {
+  } else if (err.code === 2) {
+    /* position unavailable (error response from location provider) */
     msg = 'Location information unavailable at this time.';
-  } else if (err.code === 3 /* timed out */) {
+  } else if (err.code === 3) {
+    /* timed out */
     msg = 'Timeout error getting your location.';
   } else {
-    /* unknown error */ msg = 'Unable to get your location.';
+    /* unknown error */
+    msg = 'Unable to get your location.';
   }
 
   msg = msg + '<br>Refresh your browser to try again.';

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -10,6 +10,12 @@ body,
   width: 100vw;
 }
 
+.loading-info {
+  color: #fff;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 20px;
+}
+
 .loading-spinner {
   position: fixed;
   top: 0;


### PR DESCRIPTION
This tries to improve the startup flow with respect to how we use geolocation APIs and report errors.  I've added code to set a timeout, and use cached results if available, to show better info about what's happening (error messages), and switched to using `getCurrentPosition` vs using the `watch` for the startup case.  I think this works better.

Some browsers (e.g., Chrome) still fail to load at times; but that isn't our bug.  I think it's due to not having a GPS in my desktop, and the way they are faking it via wifi isn't that fast.