### PR TITLE
spacing issue in node_modules of travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js: 'node'
 cache:
   directories:
-  - "node_modules"
+    - "node_modules"
 addons:
   chrome: stable
 before_install:


### PR DESCRIPTION
Added an extra indent for the cache options in the travis config file.
After the indent, the caching should work properly as per screenshot below.

![screenshot from 2018-04-12 11-50-50](https://user-images.githubusercontent.com/25869561/38688728-d475713e-3e47-11e8-95b3-acc21f33416d.png)
